### PR TITLE
refactoring to replace GETREF IntraOp with a map

### DIFF
--- a/src/main/java/org/usergrid/vx/experimental/IntraOp.java
+++ b/src/main/java/org/usergrid/vx/experimental/IntraOp.java
@@ -1,33 +1,52 @@
 package org.usergrid.vx.experimental;
 
-import com.google.common.base.Preconditions;
-import groovy.lang.GroovyClassLoader;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.KSMetaData;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.db.*;
-import org.apache.cassandra.db.Column;
+import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.Row;
+import org.apache.cassandra.db.RowMutation;
+import org.apache.cassandra.db.SliceByNamesReadCommand;
+import org.apache.cassandra.db.SliceFromReadCommand;
 import org.apache.cassandra.db.filter.QueryPath;
-import org.apache.cassandra.exceptions.*;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
-import org.apache.cassandra.exceptions.UnavailableException;
+import org.apache.cassandra.exceptions.IsBootstrappingException;
+import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.ReadTimeoutException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.MigrationManager;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageProxy;
-import org.apache.cassandra.thrift.*;
-import org.apache.cassandra.thrift.CqlRow._Fields;
+import org.apache.cassandra.thrift.CfDef;
+import org.apache.cassandra.thrift.ColumnPath;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.thrift.CqlRow;
+import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.transport.messages.ResultMessage.Kind;
 import org.vertx.java.core.Vertx;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import groovy.lang.GroovyClassLoader;
 
 public class IntraOp implements Serializable{
 
@@ -188,12 +207,6 @@ public class IntraOp implements Serializable{
       			return;
       		}
       		res.getOpsRes().put(i, finalResults);
-      }
-    },
-    GETREF {
-      @Override
-      public void execute(IntraReq req, IntraRes res, IntraState state, int i, Vertx vertx, IntraService is) {
-    	  //this is never used as a standalone op, but for now we can keep it here
       }
     },
     GET {

--- a/src/main/java/org/usergrid/vx/experimental/IntraService.java
+++ b/src/main/java/org/usergrid/vx/experimental/IntraService.java
@@ -6,23 +6,17 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.db.ColumnFamily;
 import org.apache.cassandra.db.IColumn;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.vertx.java.core.Vertx;
-
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class IntraService {
 
@@ -91,23 +85,15 @@ public class IntraService {
                         throw new IllegalArgumentException("Do not know what to do with " + o);
                     }
                 } else if (o instanceof IntraOp){
-			IntraOp op = (IntraOp) o;
-			if (op.getType().equals(IntraOp.Type.GETREF)){
-				Integer resultRef = (Integer) op.getOp().get("resultref");
-				String wanted = (String) op.getOp().get("wanted");
-				List aresult = (List) res.getOpsRes().get(resultRef);
-				Map result = (Map) aresult.get(0);
-				return result.get(wanted);
-			} else {
-				throw new RuntimeException(" do not know what to do with "+op.getType());
-			}
+                    IntraOp op = (IntraOp) o;
+                    throw new RuntimeException(" do not know what to do with "+op.getType());
 		} else {
 			throw new RuntimeException(" do not know what to do with "+o.getClass());
 		}
 	}
 
     private static boolean isGetRef(Object typeAttr) {
-        return typeAttr != null && typeAttr instanceof String && typeAttr.equals(IntraOp.Type.GETREF.toString());
+        return typeAttr != null && typeAttr instanceof String && typeAttr.equals("GETREF");
     }
 
     static ByteBuffer byteBufferForObject(Object o){

--- a/src/main/java/org/usergrid/vx/experimental/Operations.java
+++ b/src/main/java/org/usergrid/vx/experimental/Operations.java
@@ -1,11 +1,12 @@
 package org.usergrid.vx.experimental;
 
-import com.google.common.base.Preconditions;
-import org.apache.cassandra.db.ConsistencyLevel;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.cassandra.db.ConsistencyLevel;
 
 /**
  * Factory class for building IntraOp objects
@@ -81,14 +82,6 @@ public class Operations {
  		return new IntraOp(IntraOp.Type.GET)
              .set(ROWKEY, rowkey)
              .set(NAME, columnName);
- 	}
-
-  public static IntraOp getResRefOp(int reference, String wanted){
-    Preconditions.checkArgument(reference >= 0);
-    checkForBlankStr(wanted, WANTED, IntraOp.Type.GETREF);
-    return new IntraOp(IntraOp.Type.GETREF)
-            .set(RESULTREF, reference)
-            .set(WANTED, wanted);
  	}
 
   public static IntraOp sliceOp( Object rowkey , Object start, Object end, int size){

--- a/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
+++ b/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
@@ -1,6 +1,7 @@
 package org.usergrid.vx.experimental;
 
-import java.io.File;
+import static junit.framework.Assert.assertNotNull;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.util.ArrayList;
@@ -12,26 +13,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.db.marshal.IntegerType;
-import org.apache.cassandra.service.CassandraDaemon;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.ThriftClientState;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.usergrid.vx.server.IntravertCassandraServer;
-import org.usergrid.vx.server.IntravertDeamon;
 import org.vertx.java.core.Vertx;
-
-import static junit.framework.Assert.assertNotNull;
 
 @RunWith(CassandraRunner.class)
 @RequiresKeyspace(ksName = "myks")
@@ -52,7 +47,10 @@ public class IntraServiceITest {
 		req.add( Operations.sliceOp("rowa", "col1", "z", 4)); //4
 		req.add( Operations.getOp("rowa", "col1")); //5
 		//create a rowkey "rowb" with a column "col2" and a value of the result of operation 7
-		req.add( Operations.setOp("rowb", "col2", Operations.getResRefOp(5, "value"))); //6
+                req.add( Operations.setOp("rowb", "col2", ImmutableMap.of(
+                    "type", "GETREF",
+                    "op", ImmutableMap.of("resultref", 5, "wanted", "value")
+                ))); //6
 		//Read this row back 
 		req.add( Operations.getOp("rowb", "col2"));//7
 		
@@ -694,6 +692,6 @@ public class IntraServiceITest {
 		IntraRes res = new IntraRes();
 		is.handleIntraReq(req, res, x);
 		Assert.assertNotNull(res.getException());
-		Assert.assertEquals( new Integer(10), res.getExceptionId());
+		Assert.assertEquals(new Integer(10), res.getExceptionId());
 	}
 }

--- a/src/test/java/org/usergrid/vx/experimental/RawJsonITest.java
+++ b/src/test/java/org/usergrid/vx/experimental/RawJsonITest.java
@@ -1,7 +1,6 @@
 package org.usergrid.vx.experimental;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.util.concurrent.CountDownLatch;
 
@@ -221,7 +220,7 @@ public class RawJsonITest {
         String actualResponse = data.toString();
         String expectedResponse = loadJSON("getref_response.json");
 
-        assertJSONEquals("Failed to set column using " + IntraOp.Type.GETREF, expectedResponse, actualResponse);
+        assertJSONEquals("Failed to set column using GETREF", expectedResponse, actualResponse);
     }
 
     private String loadJSON(String file) throws Exception {


### PR DESCRIPTION
This change is a result of the discussion in
https://github.com/zznate/intravert-ug/pull/80. The GETREF IntraOp has been
removed with this commit. Its intended use was as the value of a SET IntraOp.
I already added logic in IntraService to handle a nested map in a SET command
since we do not have Jackson configured to deserialize a nested IntraOp.
IntraServiceITest has been refactored to use a nested map where GETREF was
previously used.
