### PR TITLE
Updating TypeHelper to support all C* types

### DIFF
--- a/src/main/java/org/usergrid/vx/experimental/TypeHelper.java
+++ b/src/main/java/org/usergrid/vx/experimental/TypeHelper.java
@@ -21,7 +21,6 @@ import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.TypeParser;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.SyntaxException;
-import org.apache.cassandra.utils.ByteBufferUtil;
 
 public class TypeHelper {
   public static Object getTypedIfPossible(IntraState state, String type, ByteBuffer bb, IntraOp op){
@@ -34,17 +33,9 @@ public class TypeHelper {
       return compose(bb, s);
   }
 
-    public static Object getTyped(String type, ByteBuffer bb){
-    if (type.equals("UTF-8")){
-      try {
-        return ByteBufferUtil.string(bb);
-      } catch (Exception ex){ throw new RuntimeException(ex); }
-    } else if (type.equals("int32")) {
-      return ByteBufferUtil.toInt(bb);
-    } else {
-      return bb;
+    public static Object getTyped(String type, ByteBuffer bb) {
+        return compose(bb, type);
     }
-  }
 
     public static Object getCqlTyped(String type, ByteBuffer bb) {
         if (bb == null) {

--- a/src/main/java/org/usergrid/vx/experimental/TypeHelper.java
+++ b/src/main/java/org/usergrid/vx/experimental/TypeHelper.java
@@ -16,10 +16,11 @@
 package org.usergrid.vx.experimental;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.util.List;
 
-import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.TypeParser;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 public class TypeHelper {
@@ -27,37 +28,13 @@ public class TypeHelper {
 	  
     IntraMetaData imd = new IntraMetaData(IntraService.determineKs(null ,op, state),IntraService.determineCf(null, op, state),type);
     String s = state.meta.get(imd);
-    if (s == null){
-      return bb;
-    } else if (s.equals("UTF-8")){
-      try {
-        return ByteBufferUtil.string(bb);
-      } catch (Exception ex){ throw new RuntimeException(ex); }
-    } else if (s.equals("int32")) {
-      return ByteBufferUtil.toInt(bb);
-    } else if (s.startsWith("CompositeType")){
-      int start = s.indexOf("(");
-      int end = s.indexOf(")");
-      String list = s.substring(start+1,end);
-      //System.out.println("list is" + list);
-      
-      String [] parts = list.split(",");
-      Object [] results = new Object[parts.length] ;
-      //System.out.println("parts " + parts.length);
-      byte[] by = new byte[bb.remaining()];
-      bb.get(by);
-      List<byte[]> comp = CompositeTool.readComposite(by);
-      //System.out.println("results size "+results.length);
-      //System.out.println("comp size"+ comp.size());
-      for (int i=0;i<parts.length;i++){
-        results[i]= getTyped(parts[i], ByteBuffer.wrap(comp.get(i)) ); 
+      if (s == null) {
+          return bb;
       }
-      return results;
-    } else {
-      throw new RuntimeException("Do not know what to do with "+s);
-    }
+      return compose(bb, s);
   }
-  public static Object getTyped(String type, ByteBuffer bb){
+
+    public static Object getTyped(String type, ByteBuffer bb){
     if (type.equals("UTF-8")){
       try {
         return ByteBufferUtil.string(bb);
@@ -68,19 +45,20 @@ public class TypeHelper {
       return bb;
     }
   }
-  
-  public static Object getCqlTyped(String type, ByteBuffer bb){
-	  if (bb == null){
-		  return null;
-	  }
-	  if (type.equals("UTF8Type")){
-	      try {
-	          return ByteBufferUtil.string(bb);
-	        } catch (Exception ex){ throw new RuntimeException(ex); } 
-	  }
-	  if (type.equals("Int32Type")){
-		  return Int32Type.instance.compose(bb);
-	  }
-	  throw new RuntimeException("wahat is "+type +" ?" );
-  }
+
+    public static Object getCqlTyped(String type, ByteBuffer bb) {
+        if (bb == null) {
+            return null;
+        }
+        return compose(bb, type);
+    }
+
+    private static Object compose(ByteBuffer bb, String s) {
+        try {
+            AbstractType<?> abstractType = TypeParser.parse(s);
+            return abstractType.compose(bb);
+        } catch (SyntaxException | ConfigurationException e) {
+            throw new RuntimeException("Failed to parse type [" + s + "]", e);
+        }
+    }
 }

--- a/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
+++ b/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.marshal.AbstractCompositeType;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.ThriftClientState;
@@ -119,7 +121,7 @@ public class IntraServiceITest {
 	    req.add( Operations.createCfOp("asscf")); //2
 	    req.add( Operations.setColumnFamilyOp("asscf") ); //3
 	    req.add( Operations.setAutotimestampOp() ); //4
-	    req.add( Operations.assumeOp("assks", "asscf", "value", "UTF-8"));//5
+	    req.add( Operations.assumeOp("assks", "asscf", "value", "UTF8Type"));//5
 	    req.add( Operations.setOp("rowa", "col1", "wow")); //6
 	    req.add( Operations.getOp("rowa", "col1")); //7
 	    IntraRes res = new IntraRes();
@@ -136,7 +138,7 @@ public class IntraServiceITest {
 		req.add(Operations.createCfOp("filtercf")); // 2
 		req.add(Operations.setColumnFamilyOp("filtercf")); // 3
 		req.add(Operations.setAutotimestampOp()); // 4
-		req.add(Operations.assumeOp("filterks", "filtercf", "value", "UTF-8"));// 5
+		req.add(Operations.assumeOp("filterks", "filtercf", "value", "UTF8Type"));// 5
 		req.add(Operations.setOp("rowa", "col1", "20")); // 6
 		req.add(Operations.setOp("rowa", "col2", "22")); // 7
 		req.add(Operations
@@ -152,7 +154,7 @@ public class IntraServiceITest {
 		Assert.assertEquals(1, results.size());
 
 		IntraReq req2 = new IntraReq();
-		req2.add(Operations.assumeOp("filterks", "filtercf", "value", "UTF-8"));// 0
+		req2.add(Operations.assumeOp("filterks", "filtercf", "value", "UTF8Type"));// 0
 		req2.add(Operations.filterModeOp("over21", true)); // 1
 		req2.add( Operations.sliceOp("rowa", "col1", "col3", 10) //2
 				.set("keyspace", "filterks")
@@ -176,7 +178,7 @@ public class IntraServiceITest {
         req.add(Operations.createCfOp("filtercf")); //2
         req.add(Operations.setColumnFamilyOp("filtercf")); //3
         req.add(Operations.setAutotimestampOp()); //4
-        req.add(Operations.assumeOp("jsFilterks", "filtercf", "value", "UTF-8"));//5
+        req.add(Operations.assumeOp("jsFilterks", "filtercf", "value", "UTF8Type"));//5
         req.add(Operations.setOp("rowa", "col1", "20")); //6
         req.add(Operations.setOp("rowa", "col2", "22")); //7
         req.add(Operations.createFilterOp("over21", "javascript",
@@ -200,7 +202,7 @@ public class IntraServiceITest {
      req.add( Operations.createCfOp("proccf")); //2
      req.add( Operations.setColumnFamilyOp("proccf") ); //3
      req.add( Operations.setAutotimestampOp() ); //4
-     req.add( Operations.assumeOp("procks", "proccf", "value", "UTF-8"));//5
+     req.add( Operations.assumeOp("procks", "proccf", "value", "UTF8Type"));//5
      req.add( Operations.setOp("rowa", "col1", "wow")); //6
      req.add( Operations.getOp("rowa", "col1")); //7
      req.add( Operations.createProcessorOp("capitalize", "groovy", 
@@ -237,8 +239,8 @@ public class IntraServiceITest {
      req.add( Operations.createCfOp("intcf")); //2
      req.add( Operations.setColumnFamilyOp("intcf") ); //3
      req.add( Operations.setAutotimestampOp() ); //4
-     req.add( Operations.assumeOp("intks", "intcf", "value", "UTF-8"));//5
-     req.add( Operations.assumeOp("intks", "intcf", "column", "int32"));//6
+     req.add( Operations.assumeOp("intks", "intcf", "value", "UTF8Type"));//5
+     req.add( Operations.assumeOp("intks", "intcf", "column", "Int32Type"));//6
      req.add( Operations.setOp("rowa", 1, "wow")); //7
      req.add( Operations.getOp("rowa", 1)); //8
      
@@ -257,8 +259,8 @@ public class IntraServiceITest {
 	     req.add( Operations.createCfOp("ttlcf")); //2
 	     req.add( Operations.setColumnFamilyOp("ttlcf") ); //3
 	     req.add( Operations.setAutotimestampOp() ); //4
-	     req.add( Operations.assumeOp("ttlks", "ttlcf", "value", "UTF-8"));//5
-	     req.add( Operations.assumeOp("ttlks", "ttlcf", "column", "int32"));//6
+	     req.add( Operations.assumeOp("ttlks", "ttlcf", "value", "UTF8Type"));//5
+	     req.add( Operations.assumeOp("ttlks", "ttlcf", "column", "Int32Type"));//6
 	     req.add( Operations.setOp("rowa", 1, "wow")); //7
 	     req.add( Operations.setOp("rowa", 2, "wow").set("ttl", 1)); //8
 	     //req.add( Operations.sliceOp("rowa", 1, 5, 4) ); //9
@@ -274,8 +276,8 @@ public class IntraServiceITest {
 	    IntraReq r = new IntraReq();
 	    r.add( Operations.setKeyspaceOp("ttlks") ); //0
 	    r.add( Operations.setColumnFamilyOp("ttlcf") ); //1
-	     r.add( Operations.assumeOp("ttlks", "ttlcf", "value", "UTF-8"));//2
-	     r.add( Operations.assumeOp("ttlks", "ttlcf", "column", "int32"));//3
+	     r.add( Operations.assumeOp("ttlks", "ttlcf", "value", "UTF8Type"));//2
+	     r.add( Operations.assumeOp("ttlks", "ttlcf", "column", "Int32Type"));//3
 	    r.add( Operations.sliceOp("rowa", 1, 5, 4) ); //4
 	    IntraRes rs = new IntraRes();
 	    
@@ -286,27 +288,38 @@ public class IntraServiceITest {
 	    Assert.assertEquals(1, x.size());
 	    
 	 }
-	 
-	 @Test
-   public void compositeTest() throws CharacterCodingException{ 
-     IntraReq req = new IntraReq();
-     req.add( Operations.setKeyspaceOp("compks") ); //0
-     req.add( Operations.createKsOp("compks", 1)); //1
-     req.add( Operations.createCfOp("compcf")); //2
-     req.add( Operations.setColumnFamilyOp("compcf") ); //3
-     req.add( Operations.setAutotimestampOp() ); //4
-     req.add( Operations.assumeOp("compks", "compcf", "value", "CompositeType(UTF-8,int32)"));//5
-     req.add( Operations.assumeOp("compks", "compcf", "column", "int32"));//6
-     req.add( Operations.setOp("rowa", 1, new Object[] {"yo",0, 2,0})); //7
-     req.add( Operations.getOp("rowa", 1)); //8
-      
-     IntraRes res = new IntraRes();
-     is.handleIntraReq(req, res, x);
-     List<Map> x = (List<Map>) res.getOpsRes().get(8);
-     Assert.assertEquals( 1,  x.get(0).get("name") );
-     Assert.assertEquals( "yo",  ((Object [])x.get(0).get("value"))[0] );
-     Assert.assertEquals( 2,  ((Object [])x.get(0).get("value"))[1] );
-   }
+
+    @Test
+    public void compositeTest() throws CharacterCodingException {
+        IntraReq req = new IntraReq();
+        req.add(Operations.setKeyspaceOp("compks")); //0
+        req.add(Operations.createKsOp("compks", 1)); //1
+        req.add(Operations.createCfOp("compcf")); //2
+        req.add(Operations.setColumnFamilyOp("compcf")); //3
+        req.add(Operations.setAutotimestampOp()); //4
+        req.add(Operations.assumeOp("compks", "compcf", "value", "CompositeType(UTF8Type,Int32Type)"));//5
+        req.add(Operations.assumeOp("compks", "compcf", "column", "Int32Type"));//6
+        req.add(Operations.setOp("rowa", 1, new Object[]{"yo", 0, 2, 0})); //7
+        req.add(Operations.getOp("rowa", 1)); //8
+
+        IntraRes res = new IntraRes();
+        is.handleIntraReq(req, res, x);
+        List<Map> x = (List<Map>) res.getOpsRes().get(8);
+        Assert.assertEquals(1, x.get(0).get("name"));
+
+        ByteBuffer bytes = (ByteBuffer) x.get(0).get("value");
+        List<AbstractType<?>> comparators = new ArrayList<>();
+        comparators.add(UTF8Type.instance);
+        comparators.add(Int32Type.instance);
+        CompositeType comparator = CompositeType.getInstance(comparators);
+
+        List<AbstractCompositeType.CompositeComponent> components = comparator.deconstruct(bytes);
+        AbstractCompositeType.CompositeComponent c1 = components.get(0);
+        AbstractCompositeType.CompositeComponent c2 = components.get(1);
+
+        Assert.assertEquals("yo", c1.comparator.compose(c1.value));
+        Assert.assertEquals(2, c2.comparator.compose(c2.value));
+    }
 	    
 	 
 	 @Test
@@ -317,8 +330,8 @@ public class IntraServiceITest {
      req.add( Operations.createCfOp("cqlcf")); //2
      req.add( Operations.setColumnFamilyOp("cqlcf") ); //3
      req.add( Operations.setAutotimestampOp() ); //4
-     req.add( Operations.assumeOp("cqlks", "cqlcf", "value", "int32"));//5
-     req.add( Operations.assumeOp("cqlks", "cqlcf", "column", "int32"));//6
+     req.add( Operations.assumeOp("cqlks", "cqlcf", "value", "Int32Type"));//5
+     req.add( Operations.assumeOp("cqlks", "cqlcf", "column", "Int32Type"));//6
      req.add( Operations.setOp("rowa", 1, 2)); //7
      req.add( Operations.getOp("rowa", 1)); //8
      req.add( Operations.cqlQuery("select * from cqlcf", "3.0.0"));//9
@@ -357,7 +370,7 @@ public class IntraServiceITest {
      req.add( Operations.createCfOp("clearcf")); //2
      req.add( Operations.setColumnFamilyOp("clearcf") ); //3
      req.add( Operations.setAutotimestampOp() ); //4
-     req.add( Operations.assumeOp("clearks", "clearcf", "value", "UTF-8")); //5
+     req.add( Operations.assumeOp("clearks", "clearcf", "value", "UTF8Type")); //5
      req.add( Operations.setOp("rowa", 1, "wow")); //6
      req.add( Operations.getOp("rowa", 1)); //7
      req.add( Operations.getOp("rowa", 1)); //8
@@ -406,7 +419,7 @@ public class IntraServiceITest {
     req.add( Operations.setKeyspaceOp("myks") ); //0
     req.add( Operations.setColumnFamilyOp("mycf") ); //1
     req.add(Operations.setAutotimestampOp()); //2
-    req.add(Operations.assumeOp("myks", "mycf", "value", "UTF-8")); //3
+    req.add(Operations.assumeOp("myks", "mycf", "value", "UTF8Type")); //3
     req.add(Operations.setOp("rowzz", "col1", "7")); //4
     req.add(Operations.setOp("rowzz", "col2", "8")); //5
     req.add( Operations.setOp("rowyy", "col4", "9")); //6
@@ -457,8 +470,8 @@ public class IntraServiceITest {
     req.add( Operations.setKeyspaceOp("myks") ); //0
     req.add( Operations.setColumnFamilyOp("mycf") ); //1
     req.add( Operations.setAutotimestampOp() ); //2
-    req.add( Operations.assumeOp("myks", "mycf", "value", "UTF-8")); //3
-    req.add( Operations.assumeOp("myks", "mycf", "column", "UTF-8")); //4
+    req.add( Operations.assumeOp("myks", "mycf", "value", "UTF8Type")); //3
+    req.add( Operations.assumeOp("myks", "mycf", "column", "UTF8Type")); //4
     Map row1 = new HashMap();
     row1.put("rowkey", "batchkeya");
     row1.put("name", "col1");
@@ -520,8 +533,8 @@ public class IntraServiceITest {
     req.add( Operations.setKeyspaceOp("myks") ); //0
     req.add( Operations.setColumnFamilyOp("mycf") ); //1
     req.add( Operations.setAutotimestampOp() ); //2
-    req.add( Operations.assumeOp("myks", "mycf", "value", "UTF-8")); //3
-    req.add( Operations.assumeOp("myks", "mycf", "column", "UTF-8")); //4
+    req.add( Operations.assumeOp("myks", "mycf", "value", "UTF8Type")); //3
+    req.add( Operations.assumeOp("myks", "mycf", "column", "UTF8Type")); //4
     Map row1 = new HashMap();
     row1.put("rowkey", "jsonkey");
     row1.put("name", "data");
@@ -572,7 +585,7 @@ public class IntraServiceITest {
     r.add( Operations.setColumnFamilyOp("mycf")); //1
     r.add( Operations.setAutotimestampOp() ); //2
     r.add( Operations.setOp("a", "b", "c") ); //3
-    r.add( Operations.assumeOp("myks", "mycf", "value", "UTF-8") );//4
+    r.add( Operations.assumeOp("myks", "mycf", "value", "UTF8Type") );//4
     r.add( Operations.saveState() );//5
     
     IntraRes res = new IntraRes();
@@ -631,8 +644,8 @@ public class IntraServiceITest {
 	     IntraReq req = new IntraReq();
 	    
 	     req.add( Operations.setAutotimestampOp() ); //0
-	     req.add( Operations.assumeOp("myks", "mycf", "value", "UTF-8"));//1
-	     req.add( Operations.assumeOp("myks", "mycf", "column", "int32"));//2
+	     req.add( Operations.assumeOp("myks", "mycf", "value", "UTF8Type"));//1
+	     req.add( Operations.assumeOp("myks", "mycf", "column", "Int32Type"));//2
 	     IntraOp setOp = Operations.setOp("optional", 1, "wow"); //3
 	     setOp.set("keyspace", "myks");
 	     setOp.set("columnfamily", "mycf");
@@ -655,8 +668,8 @@ public class IntraServiceITest {
 	public void componentTest() {
 		IntraReq req = new IntraReq();
 		req.add(Operations.setAutotimestampOp()); // 0
-		req.add(Operations.assumeOp("myks", "mycf", "value", "UTF-8"));// 1
-		req.add(Operations.assumeOp("myks", "mycf", "column", "int32"));// 2
+		req.add(Operations.assumeOp("myks", "mycf", "value", "UTF8Type"));// 1
+		req.add(Operations.assumeOp("myks", "mycf", "column", "Int32Type"));// 2
 		IntraOp setOp = Operations.setOp("optional", 1, "wow"); // 3
 		setOp.set("keyspace", "myks");
 		setOp.set("columnfamily", "mycf");
@@ -720,7 +733,7 @@ public class IntraServiceITest {
 		req.add(Operations.createCfOp("timeoutcf")); // 2
 		req.add(Operations.setColumnFamilyOp("timeoutcf")); // 3
 		req.add(Operations.setAutotimestampOp()); // 4
-		req.add(Operations.assumeOp("timeoutks", "timeoutcf", "value", "UTF-8"));// 5
+		req.add(Operations.assumeOp("timeoutks", "timeoutcf", "value", "UTF8Type"));// 5
 		req.add(Operations.setOp("rowa", "col1", "20")); // 6
 		req.add(Operations.setOp("rowa", "col2", "22")); // 7
                 req.add(Operations.createFilterOp("ALongOne", "groovy", "{ row -> Thread.sleep(5000) }")); // 8
@@ -759,8 +772,8 @@ public class IntraServiceITest {
 			.add( Operations.setKeyspaceOp("ks2"))
 			.add( Operations.createCfOp("cf2"))
 			.add( Operations.batchSetOp(batch).set("timeout", 1000000))
-			.add( Operations.assumeOp("ks1", "cf1", "value", "UTF-8"))
-			.add( Operations.assumeOp("ks2", "cf2", "value", "UTF-8"))
+			.add( Operations.assumeOp("ks1", "cf1", "value", "UTF8Type"))
+			.add( Operations.assumeOp("ks2", "cf2", "value", "UTF8Type"))
 			.add( Operations.getOp("mykey", "mycol")
 					.set("keyspace", "ks1")
 					.set("columnfamily", "cf1"));
@@ -817,8 +830,8 @@ public class IntraServiceITest {
 						+ "import org.usergrid.vx.experimental.scan.* \n"
 						+ "public class MyScanner extends PeopleFromNY { \n"
 						+ " public MyScanner() { super(); } \n" + "} \n"))
-				.add(Operations.assumeOp("myks", "mycf", "value", "UTF-8"))
-				.add(Operations.assumeOp("myks", "mycf", "column", "UTF-8"))
+				.add(Operations.assumeOp("myks", "mycf", "value", "UTF8Type"))
+				.add(Operations.assumeOp("myks", "mycf", "column", "UTF8Type"))
 				.add(Operations.setKeyspaceOp("myks"))
 				.add(Operations.setColumnFamilyOp("mycf"))
 				.add(Operations.setOp("scannerrow", "ed", "NY")) // 3
@@ -848,8 +861,8 @@ public class IntraServiceITest {
 	public void sliceNamesTest() throws Exception {
 		IntraReq req = new IntraReq();
 		req.add(
-				Operations.assumeOp("myks", "mycf", "value", "UTF-8")) 
-				.add(Operations.assumeOp("myks", "mycf", "column", "UTF-8"))
+				Operations.assumeOp("myks", "mycf", "value", "UTF8Type")) 
+				.add(Operations.assumeOp("myks", "mycf", "column", "UTF8Type"))
 				.add(Operations.setKeyspaceOp("myks"))
 				.add(Operations.setColumnFamilyOp("mycf"))
 				.add(Operations.setOp("slicename", "ed", "NY")) // 4


### PR DESCRIPTION
I refactored TypeHelper to use org.apache.cassandra.db.marshal.TypeParser which allowed me to get rid of most of the code in TypeHelper. Using TypeParser gives us support for all of the C\* types. This did however necessitate some changes to test code in IntraServiceITest. The test was previously specifying types as UTF-8 and int32. I to change those to UTF8Type and Int32Type respectively. You also find that I had to refactor the compositeTest method to parse out the buffers.

If we're good with these changes, I'll update examples in the docs as well.
