### PR TITLE
make HandlerUtils.readCf create and return a JsonArray of columns

### DIFF
--- a/src/main/java/org/usergrid/vx/server/operations/GetHandler.java
+++ b/src/main/java/org/usergrid/vx/server/operations/GetHandler.java
@@ -1,76 +1,64 @@
 package org.usergrid.vx.server.operations;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.cassandra.db.ColumnFamily;
-import org.apache.cassandra.db.ConsistencyLevel;
-import org.apache.cassandra.db.IColumn;
-import org.apache.cassandra.db.ReadCommand;
-import org.apache.cassandra.db.Row;
-import org.apache.cassandra.db.SliceByNamesReadCommand;
+import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.QueryPath;
 import org.apache.cassandra.exceptions.IsBootstrappingException;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.service.StorageProxy;
 import org.usergrid.vx.experimental.IntraService;
-import org.usergrid.vx.experimental.TypeHelper;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.eventbus.Message;
 import org.vertx.java.core.json.JsonArray;
 import org.vertx.java.core.json.JsonObject;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 public class GetHandler implements Handler<Message<JsonObject>> {
 
-    @Override
-    public void handle(Message<JsonObject> event) {
-        Integer id = event.body.getInteger("id");
-        JsonObject params = event.body.getObject("op");
-        JsonObject state = event.body.getObject("state");
+  @Override
+  public void handle(Message<JsonObject> event) {
+    Integer id = event.body.getInteger("id");
+    JsonObject params = event.body.getObject("op");
+    JsonObject state = event.body.getObject("state");
 
-        Map<String, Object> paramsMap = params.toMap();
-        Object rowKeyParam = paramsMap.get("rowkey");
-        Object nameParam = paramsMap.get("name");
-        List<Map> finalResults = new ArrayList<Map>();
+    Map<String, Object> paramsMap = params.toMap();
+    Object rowKeyParam = paramsMap.get("rowkey");
+    Object nameParam = paramsMap.get("name");
+    List<Map> finalResults = new ArrayList<Map>();
 
-        ByteBuffer rowkey = IntraService.byteBufferForObject(IntraService.resolveObject(rowKeyParam, null, null, null,
-            id));
-        ByteBuffer column = IntraService.byteBufferForObject(IntraService.resolveObject(nameParam, null, null, null,
-            id));
-        QueryPath path = new QueryPath(HandlerUtils.determineCf(params, state), null);
-        List<ByteBuffer> nameAsList = Arrays.asList(column);
-        ReadCommand command = new SliceByNamesReadCommand(HandlerUtils.determineKs(params, state), rowkey, path, nameAsList);
-        List<Row> rows = null;
+    ByteBuffer rowkey = IntraService.byteBufferForObject(IntraService.resolveObject(rowKeyParam, null, null, null,
+        id));
+    ByteBuffer column = IntraService.byteBufferForObject(IntraService.resolveObject(nameParam, null, null, null,
+        id));
+    QueryPath path = new QueryPath(HandlerUtils.determineCf(params, state), null);
+    List<ByteBuffer> nameAsList = Arrays.asList(column);
+    ReadCommand command = new SliceByNamesReadCommand(HandlerUtils.determineKs(params, state), rowkey, path, nameAsList);
+    List<Row> rows = null;
 
-        try {
-            // We don't want to hard code the consistency level but letting it slide for
-            // since it is also hard coded in IntraState
-            rows = StorageProxy.read(Arrays.asList(command), ConsistencyLevel.ONE);
-            ColumnFamily cf1 = rows.get(0).cf;
-            if (cf1 == null) { // cf= null is no data
-            } else {
-                HandlerUtils.readCf(cf1, finalResults, state, params);
-            }
+    try {
+      // We don't want to hard code the consistency level but letting it slide for
+      // since it is also hard coded in IntraState
+      rows = StorageProxy.read(Arrays.asList(command), ConsistencyLevel.ONE);
+      ColumnFamily cf1 = rows.get(0).cf;
+      JsonArray array;
+      if (cf1 == null) { // cf= null is no data
+        array = new JsonArray();
+      } else {
+        array = HandlerUtils.readCf(cf1, state, params);
+      }
 
-            JsonObject response = new JsonObject();
-            JsonArray array = new JsonArray();
-            for (Map m : finalResults) {
-                array.add(new JsonObject(m));
-            }
-            response.putArray(id.toString(), array);
-            event.reply(response);
-        } catch (ReadTimeoutException | UnavailableException | IsBootstrappingException | IOException e) {
-            event.reply(new JsonObject().putString(id.toString(), e.getMessage()));
-        }
+      JsonObject response = new JsonObject();
+      response.putArray(id.toString(), array);
+      event.reply(response);
+    } catch (ReadTimeoutException | UnavailableException | IsBootstrappingException | IOException e) {
+      event.reply(new JsonObject().putString(id.toString(), e.getMessage()));
     }
-
-
+  }
 
 }

--- a/src/main/java/org/usergrid/vx/server/operations/HandlerUtils.java
+++ b/src/main/java/org/usergrid/vx/server/operations/HandlerUtils.java
@@ -8,8 +8,6 @@ import org.vertx.java.core.json.JsonObject;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author zznate
@@ -36,32 +34,33 @@ public class HandlerUtils {
       return ks;
   }
 
-  public static void readCf(ColumnFamily columnFamily, List<Map> finalResults, JsonObject state, JsonObject params) {
-      Iterator<IColumn> it = columnFamily.iterator();
-      while (it.hasNext()) {
-          IColumn ic = it.next();
-          if (ic.isLive()) {
-              HashMap m = new HashMap();
-              JsonArray components = state.getArray("components");
+  public static JsonArray readCf(ColumnFamily columnFamily, JsonObject state, JsonObject params) {
+    JsonArray components = state.getArray("components");
+    JsonArray array = new JsonArray();
+    Iterator<IColumn> it = columnFamily.iterator();
+    while (it.hasNext()) {
+      IColumn ic = it.next();
+      if (ic.isLive()) {
+        HashMap m = new HashMap();
 
-              if (components.contains("name")) {
-                  String clazz = state.getObject("meta").getObject("column").getString("clazz");
-                  m.put("name", TypeHelper.getTyped(clazz, ic.name()));
-              }
-              if (components.contains("value")) {
-                  String clazz = state.getObject("meta").getObject("value").getString("clazz");
-                  m.put("value", TypeHelper.getTyped(clazz, ic.value()));
-              }
-              if (components.contains("timestamp")) {
-                  m.put("timestamp", ic.timestamp());
-              }
-              if (components.contains("markeddelete")) {
-                  m.put("markeddelete", ic.getMarkedForDeleteAt());
-              }
-
-              finalResults.add(m);
-          }
+        if (components.contains("name")) {
+          String clazz = state.getObject("meta").getObject("column").getString("clazz");
+          m.put("name", TypeHelper.getTyped(clazz, ic.name()));
+        }
+        if (components.contains("value")) {
+          String clazz = state.getObject("meta").getObject("value").getString("clazz");
+          m.put("value", TypeHelper.getTyped(clazz, ic.value()));
+        }
+        if (components.contains("timestamp")) {
+          m.put("timestamp", ic.timestamp());
+        }
+        if (components.contains("markeddelete")) {
+          m.put("markeddelete", ic.getMarkedForDeleteAt());
+        }
+        array.addObject(new JsonObject(m));
       }
+    }
+    return array;
   }
 
 }

--- a/src/main/java/org/usergrid/vx/server/operations/SliceHandler.java
+++ b/src/main/java/org/usergrid/vx/server/operations/SliceHandler.java
@@ -1,81 +1,70 @@
 package org.usergrid.vx.server.operations;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.cassandra.db.ColumnFamily;
-import org.apache.cassandra.db.ConsistencyLevel;
-import org.apache.cassandra.db.IColumn;
-import org.apache.cassandra.db.ReadCommand;
-import org.apache.cassandra.db.Row;
-import org.apache.cassandra.db.SliceFromReadCommand;
+import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.QueryPath;
 import org.apache.cassandra.exceptions.IsBootstrappingException;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.service.StorageProxy;
-import org.apache.cassandra.thrift.ColumnPath;
 import org.usergrid.vx.experimental.IntraService;
-import org.usergrid.vx.experimental.TypeHelper;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.eventbus.Message;
 import org.vertx.java.core.json.JsonArray;
 import org.vertx.java.core.json.JsonObject;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 public class SliceHandler implements Handler<Message<JsonObject>> {
 
-    @Override
-    public void handle(Message<JsonObject> event) {
-        Integer id = event.body.getInteger("id");
-        JsonObject params = event.body.getObject("op");
-        JsonObject state = event.body.getObject("state");
+  @Override
+  public void handle(Message<JsonObject> event) {
+    Integer id = event.body.getInteger("id");
+    JsonObject params = event.body.getObject("op");
+    JsonObject state = event.body.getObject("state");
 
-        List<Map> finalResults = new ArrayList<Map>();
-        Map<String, Object> paramsMap = params.toMap();
-        Object rowKeyParam = paramsMap.get("rowkey");
-        Object startParam = paramsMap.get("start");
-        Object endParam = paramsMap.get("end");
+    List<Map> finalResults = new ArrayList<Map>();
+    Map<String, Object> paramsMap = params.toMap();
+    Object rowKeyParam = paramsMap.get("rowkey");
+    Object startParam = paramsMap.get("start");
+    Object endParam = paramsMap.get("end");
 
-        ByteBuffer rowkey = IntraService
-            .byteBufferForObject(IntraService.resolveObject(rowKeyParam, null, null, null, id));
-        ByteBuffer start = IntraService.byteBufferForObject(IntraService.resolveObject(startParam, null, null, null, id));
-        ByteBuffer end = IntraService.byteBufferForObject(IntraService.resolveObject(endParam, null, null, null, id));
+    ByteBuffer rowkey = IntraService
+        .byteBufferForObject(IntraService.resolveObject(rowKeyParam, null, null, null, id));
+    ByteBuffer start = IntraService.byteBufferForObject(IntraService.resolveObject(startParam, null, null, null, id));
+    ByteBuffer end = IntraService.byteBufferForObject(IntraService.resolveObject(endParam, null, null, null, id));
 
-        List<ReadCommand> commands = new ArrayList<ReadCommand>(1);
+    List<ReadCommand> commands = new ArrayList<ReadCommand>(1);
 
-        QueryPath path = new QueryPath(HandlerUtils.determineCf(params, state), null);
+    QueryPath path = new QueryPath(HandlerUtils.determineCf(params, state), null);
 
-        SliceFromReadCommand sr = new SliceFromReadCommand(state.getString("currentKeyspace"), rowkey, path, start, end,
-            false, 100);
-        commands.add(sr);
+    SliceFromReadCommand sr = new SliceFromReadCommand(state.getString("currentKeyspace"), rowkey, path, start, end,
+        false, 100);
+    commands.add(sr);
 
-        List<Row> results = null;
-        try {
-            // We don't want to hard code the consistency level but letting it slide for
-            // since it is also hard coded in IntraState
-            results = StorageProxy.read(commands, ConsistencyLevel.ONE);
-            ColumnFamily cf = results.get(0).cf;
-            if (cf == null){ //cf= null is no data
-            } else {
-                HandlerUtils.readCf(cf, finalResults, state, params);
-            }
+    List<Row> results = null;
+    try {
+      // We don't want to hard code the consistency level but letting it slide for
+      // since it is also hard coded in IntraState
+      results = StorageProxy.read(commands, ConsistencyLevel.ONE);
+      ColumnFamily cf = results.get(0).cf;
+      JsonArray array;
 
-            JsonObject response = new JsonObject();
-            JsonArray array = new JsonArray();
-            for (Map m : finalResults) {
-                array.add(new JsonObject(m));
-            }
-            response.putArray(id.toString(), array);
-            event.reply(response);
-        } catch (ReadTimeoutException | UnavailableException | IsBootstrappingException | IOException e) {
-            event.reply(new JsonObject().putString(id.toString(), e.getMessage()));
-        }
+      if (cf == null) { //cf= null is no data
+        array  = new JsonArray();
+      } else {
+        array = HandlerUtils.readCf(cf, state, params);
+      }
+
+      JsonObject response = new JsonObject();
+      response.putArray(id.toString(), array);
+      event.reply(response);
+    } catch (ReadTimeoutException | UnavailableException | IsBootstrappingException | IOException e) {
+      event.reply(new JsonObject().putString(id.toString(), e.getMessage()));
     }
-
+  }
 
 }


### PR DESCRIPTION
While I was looking at something else, I noticed that the callers of
HandlerUtils.readCf both take the list of maps that gets populated, iterates
through the list, converts each map to a JsonObject, and then adds that object
to a JsonArray that is sent back in the response to the reply handler.

This commit removes that duplicate work and also eliminates the extra work of
looping over all of the columns again. This change will also help with some stuff I am looking to do for issue #115.
