### PR TITLE
fix IntraServiceITest.compositeTest

### DIFF
--- a/src/main/java/org/usergrid/vx/experimental/TypeHelper.java
+++ b/src/main/java/org/usergrid/vx/experimental/TypeHelper.java
@@ -15,41 +15,48 @@
 */
 package org.usergrid.vx.experimental;
 
-import java.nio.ByteBuffer;
-
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.TypeParser;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.SyntaxException;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import java.nio.ByteBuffer;
 
 public class TypeHelper {
-  public static Object getTypedIfPossible(IntraState state, String type, ByteBuffer bb, IntraOp op){
-	  
-    IntraMetaData imd = new IntraMetaData(IntraService.determineKs(null ,op, state),IntraService.determineCf(null, op, state),type);
+  public static Object getTypedIfPossible(IntraState state, String type, ByteBuffer bb, IntraOp op) {
+
+    IntraMetaData imd = new IntraMetaData(IntraService.determineKs(null, op, state), IntraService.determineCf(null, op, state), type);
     String s = state.meta.get(imd);
-      if (s == null) {
-          return bb;
-      }
-      return compose(bb, s);
+    if (s == null) {
+      return bb;
+    }
+    return compose(bb, s);
   }
 
-    public static Object getTyped(String type, ByteBuffer bb) {
-        return compose(bb, type);
-    }
+  public static Object getTyped(String type, ByteBuffer bb) {
+    return compose(bb, type);
+  }
 
-    public static Object getCqlTyped(String type, ByteBuffer bb) {
-        if (bb == null) {
-            return null;
-        }
-        return compose(bb, type);
+  public static Object getCqlTyped(String type, ByteBuffer bb) {
+    if (bb == null) {
+      return null;
     }
+    return compose(bb, type);
+  }
 
-    private static Object compose(ByteBuffer bb, String s) {
-        try {
-            AbstractType<?> abstractType = TypeParser.parse(s);
-            return abstractType.compose(bb);
-        } catch (SyntaxException | ConfigurationException e) {
-            throw new RuntimeException("Failed to parse type [" + s + "]", e);
-        }
+  private static Object compose(ByteBuffer bb, String s) {
+    try {
+      AbstractType<?> abstractType = TypeParser.parse(s);
+      return abstractType.compose(bb);
+    } catch (SyntaxException | ConfigurationException e) {
+      throw new RuntimeException("Failed to parse type [" + s + "]", e);
     }
+  }
+
+  public static byte[] getBytes(ByteBuffer buffer) {
+    // TODO figure out more efficient way to pull bytes out of buffer
+    return ByteBufferUtil.getArray(buffer);
+  }
+
 }

--- a/src/main/java/org/usergrid/vx/server/operations/HandlerUtils.java
+++ b/src/main/java/org/usergrid/vx/server/operations/HandlerUtils.java
@@ -13,6 +13,7 @@ import org.vertx.java.core.eventbus.Message;
 import org.vertx.java.core.json.JsonArray;
 import org.vertx.java.core.json.JsonObject;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -54,10 +55,15 @@ public class HandlerUtils {
         if (components.contains("name")) {
           JsonObject columnMetadata = state.getObject("meta").getObject("column");
           if (columnMetadata == null) {
-            m.put("name", ByteBufferUtil.getArray(ic.name()));
+            m.put("name", TypeHelper.getBytes(ic.name()));
           } else {
             String clazz = columnMetadata.getString("clazz");
-            m.put("name", TypeHelper.getTyped(clazz, ic.name()));
+            Object name = TypeHelper.getTyped(clazz, ic.name());
+            if (name instanceof ByteBuffer) {
+              m.put("name", TypeHelper.getBytes(ic.name()));
+            } else {
+              m.put("name", TypeHelper.getTyped(clazz, ic.name()));
+            }
           }
         }
         if (components.contains("value")) {
@@ -66,10 +72,15 @@ public class HandlerUtils {
           } else {
             JsonObject valueMetadata = state.getObject("meta").getObject("value");
             if (valueMetadata == null) {
-              m.put("value", ByteBufferUtil.getArray(ic.value()));
+              m.put("value", TypeHelper.getBytes(ic.value()));
             } else {
               String clazz = valueMetadata.getString("clazz");
-              m.put("value", TypeHelper.getTyped(clazz, ic.value()));
+              Object value = TypeHelper.getTyped(clazz, ic.value());
+              if (value instanceof ByteBuffer) {
+                m.put("value", TypeHelper.getBytes(ic.value()));
+              } else {
+                m.put("value", value);
+              }
             }
           }
         }

--- a/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
+++ b/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import org.usergrid.vx.client.IntraClient;
 import org.usergrid.vx.client.IntraClient2;
 import org.vertx.java.core.Vertx;
+import org.vertx.java.core.http.impl.ws.Base64;
 
 @RunWith(CassandraRunner.class)
 @RequiresKeyspace(ksName = "myks")
@@ -300,37 +301,40 @@ public class IntraServiceITest {
 	    
 	 }
 
-    @Test
-    public void compositeTest() throws Exception {
-        IntraReq req = new IntraReq();
-        req.add(Operations.setKeyspaceOp("compks")); //0
-        req.add(Operations.createKsOp("compks", 1)); //1
-        req.add(Operations.createCfOp("compcf")); //2
-        req.add(Operations.setColumnFamilyOp("compcf")); //3
-        req.add(Operations.setAutotimestampOp(true)); //4
-        req.add(Operations.assumeOp("compks", "compcf", "value", "CompositeType(UTF8Type,Int32Type)"));//5
-        req.add(Operations.assumeOp("compks", "compcf", "column", "Int32Type"));//6
-        req.add(Operations.setOp("rowa", 1, new Object[]{"yo", 0, 2, 0})); //7
-        req.add(Operations.getOp("rowa", 1)); //8
+  @Test
+  public void compositeTest() throws Exception {
+    IntraReq req = new IntraReq();
+    req.add(Operations.setKeyspaceOp("compks")); //0
+    req.add(Operations.createKsOp("compks", 1)); //1
+    req.add(Operations.createCfOp("compcf")); //2
+    req.add(Operations.setColumnFamilyOp("compcf")); //3
+    req.add(Operations.setAutotimestampOp(true)); //4
+    req.add(Operations.assumeOp("compks", "compcf", "value", "CompositeType(UTF8Type,Int32Type)"));//5
+    req.add(Operations.assumeOp("compks", "compcf", "column", "Int32Type"));//6
+    req.add(Operations.setOp("rowa", 1, new Object[]{"yo", 0, 2, 0})); //7
+    req.add(Operations.getOp("rowa", 1)); //8
 
-        IntraClient2 ic2 = new IntraClient2("localhost", 8080);
-        IntraRes res = ic2.sendBlocking(req);
-        List<Map> x = (List<Map>) res.getOpsRes().get(8);
-        Assert.assertEquals(1, x.get(0).get("name"));
+    IntraClient2 ic2 = new IntraClient2("localhost", 8080);
+    IntraRes res = ic2.sendBlocking(req);
+    List<Map> x = (List<Map>) res.getOpsRes().get(8);
+    Assert.assertEquals(1, x.get(0).get("name"));
 
-        ByteBuffer bytes = (ByteBuffer) x.get(0).get("value");
-        List<AbstractType<?>> comparators = new ArrayList<>();
-        comparators.add(UTF8Type.instance);
-        comparators.add(Int32Type.instance);
-        CompositeType comparator = CompositeType.getInstance(comparators);
+//        ByteBuffer bytes = (ByteBuffer) x.get(0).get("value");
+    String value = (String) x.get(0).get("value");
+    ByteBuffer bytes = ByteBuffer.wrap(Base64.decode(value));
 
-        List<AbstractCompositeType.CompositeComponent> components = comparator.deconstruct(bytes);
-        AbstractCompositeType.CompositeComponent c1 = components.get(0);
-        AbstractCompositeType.CompositeComponent c2 = components.get(1);
+    List<AbstractType<?>> comparators = new ArrayList<>();
+    comparators.add(UTF8Type.instance);
+    comparators.add(Int32Type.instance);
+    CompositeType comparator = CompositeType.getInstance(comparators);
 
-        Assert.assertEquals("yo", c1.comparator.compose(c1.value));
-        Assert.assertEquals(2, c2.comparator.compose(c2.value));
-    }
+    List<AbstractCompositeType.CompositeComponent> components = comparator.deconstruct(bytes);
+    AbstractCompositeType.CompositeComponent c1 = components.get(0);
+    AbstractCompositeType.CompositeComponent c2 = components.get(1);
+
+    Assert.assertEquals("yo", c1.comparator.compose(c1.value));
+    Assert.assertEquals(2, c2.comparator.compose(c2.value));
+  }
 	    
 	 
 	 @Test
@@ -697,7 +701,7 @@ public class IntraServiceITest {
 
 		Assert.assertEquals("wow", x.get(0).get("value"));
 		Assert.assertEquals(true, x.get(0).containsKey("timestamp"));
-		Assert.assertTrue( (Long)x.get(0).get("timestamp") > 0);
+		Assert.assertTrue((Long) x.get(0).get("timestamp") > 0);
 		Assert.assertTrue( x.get(0).get("name") == null);
 	}
 	
@@ -823,7 +827,7 @@ public class IntraServiceITest {
 		IntraReq req3 = new IntraReq();
 		Map m = new HashMap();
 		m.put(new Integer(1),"preparedrow1");
-		req3.add( Operations.executePrepared(preparedId, m));
+		req3.add(Operations.executePrepared(preparedId, m));
 		IntraRes res3 = ic2.sendBlocking(req);
 		List<Map> x = (List<Map>) res3.getOpsRes().get(0);
 		Assert.assertEquals("preparedvalue1", ByteBufferUtil.string( (ByteBuffer) x.get(0).get("value")));


### PR DESCRIPTION
Had to make a couple changes. In HandlerUtils.readCf I added another check for the name or value being a ByteBuffer after type conversion which happens in the case of composites. The ByteBuffer has to get converted to a byte[] before getting stored in a JsonObject. Then in the test code I had to refactor the compositeTest method a bit to decode the bytes and put them back into a ByteBuffer.
