### PR TITLE
Counters are now properly treated as longs

### DIFF
--- a/src/main/java/org/usergrid/vx/experimental/Operations.java
+++ b/src/main/java/org/usergrid/vx/experimental/Operations.java
@@ -116,7 +116,7 @@ public class Operations {
              .set(WANTEDCOLS, columnList).set("rowkey",rowkey);
  	}
 
-  public static IntraOp counter( Object rowkey, Object columnName, long value) {
+  public static IntraOp counter( Object rowkey, Object columnName, Long value) {
     Preconditions.checkArgument(rowkey != null,"A row key is required for {}", IntraOp.Type.COUNTER);
     Preconditions.checkArgument(columnName != null,"A column name is required for {}", IntraOp.Type.COUNTER);
     return new IntraOp(IntraOp.Type.COUNTER)

--- a/src/main/java/org/usergrid/vx/server/operations/CounterHandler.java
+++ b/src/main/java/org/usergrid/vx/server/operations/CounterHandler.java
@@ -4,7 +4,6 @@ import org.apache.cassandra.db.CounterMutation;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.RowMutation;
 import org.apache.cassandra.db.filter.QueryPath;
-import org.vertx.java.core.Handler;
 import org.vertx.java.core.eventbus.Message;
 import org.vertx.java.core.json.JsonObject;
 
@@ -14,12 +13,11 @@ import java.util.List;
 /**
  * Handler class for counter writes
  *
- * @author zznate
  */
-public class CounterHandler implements Handler<Message<JsonObject>> {
+public class CounterHandler extends AbstractIntravertHandler {
 
   @Override
-  public void handle(Message<JsonObject> event) {
+  public void handleUser(Message<JsonObject> event) {
     Integer id = event.body.getInteger("id");
     JsonObject params = event.body.getObject("op");
     JsonObject state = event.body.getObject("state");

--- a/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
+++ b/src/test/java/org/usergrid/vx/experimental/IntraServiceITest.java
@@ -795,7 +795,6 @@ public class IntraServiceITest {
   }
 
   @Test
-  @Ignore
   @RequiresColumnFamily(ksName = "myks", cfName = "mycountercf", isCounter = true)
   public void counterNoodling() throws Exception {
     IntraReq req = new IntraReq();
@@ -803,18 +802,19 @@ public class IntraServiceITest {
             .add(Operations.assumeOp("myks", "mycountercf", "column", "UTF8Type"))
             .add(Operations.setKeyspaceOp("myks"))
             .add(Operations.setColumnFamilyOp("mycountercf"))
-            .add(Operations.counter("counter_key", "counter_name_1", 1).set("timeout", 30000))
+            .add(Operations.counter("counter_key", "counter_name_1", 1L).set("timeout", 30000))
             // 4
             .add(Operations.getOp("counter_key", "counter_name_1"))
-            .add(Operations.counter("counter_key", "counter_name_1", 4).set("timeout", 30000))
+            .add(Operations.counter("counter_key", "counter_name_1", new Long((long) Integer.MAX_VALUE+10L)).set("timeout", 30000))
             .add(Operations.getOp("counter_key", "counter_name_1"));
 
     IntraClient2 ic2 = new IntraClient2("localhost", 8080);
     IntraRes res = ic2.sendBlocking(req);
     List<Map> results = (List<Map>) res.getOpsRes().get(5);
     logger.info("has results {}", results);
-    Assert.assertEquals(1L, results.get(0).get("value"));
-    results = (List<Map>) res.getOpsRes().get(7);
-    Assert.assertEquals(5L, results.get(0).get("value"));
+    Assert.assertEquals(1, results.get(0).get("value"));
+    results = (List<Map>) res.getOpsRes().get(7);   
+    Assert.assertEquals(2147483658L, results.get(0).get("value"));
+    Assert.assertTrue( (Long) results.get(0).get("value") > Integer.MAX_VALUE );
   }
 }


### PR DESCRIPTION
So Jackson/vertx/us is doing something fishy with long -> int conversions. It is rather annoying that get_count can return int or long depending on the size. However this patch allows us to treat coutners as long, maybe as a follow on we can come up with a way for them to always return a long. For now the client simply has to be aware that if the counter < Integer.Max_value intravert will return an integer.
