### PR TITLE
exceptionID should always be a string

### DIFF
--- a/src/main/java/org/usergrid/vx/experimental/IntraRes.java
+++ b/src/main/java/org/usergrid/vx/experimental/IntraRes.java
@@ -77,7 +77,7 @@ public class IntraRes implements Serializable {
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
     json.putObject("exception", null);
-    json.putNumber("exceptionId", exceptionId);
+    json.putString("exceptionId", String.valueOf(exceptionId));
     json.putElement("opsRes", new JsonObject((Map) opsRes));
     return json;
   }

--- a/src/main/java/org/usergrid/vx/server/operations/CreateColumnFamilyHandler.java
+++ b/src/main/java/org/usergrid/vx/server/operations/CreateColumnFamilyHandler.java
@@ -35,12 +35,12 @@ public class CreateColumnFamilyHandler implements Handler<Message<JsonObject>> {
             cfm.addDefaultIndexNames();
         } catch (org.apache.cassandra.exceptions.InvalidRequestException e) {
             response.putString("exception", e.getMessage());
-            response.putNumber("exceptionId", id);
+            response.putString("exceptionId", String.valueOf(id));
             event.reply(response);
             return;
         } catch (ConfigurationException e) {
             response.putString("exception", e.getMessage());
-            response.putNumber("exceptionId", id);
+            response.putString("exceptionId", String.valueOf(id));
             event.reply(response);
             return;
         }
@@ -48,7 +48,7 @@ public class CreateColumnFamilyHandler implements Handler<Message<JsonObject>> {
             MigrationManager.announceNewColumnFamily(cfm);
         } catch (ConfigurationException e) {
             response.putString("exception", e.getMessage());
-            response.putNumber("exceptionId", id);
+            response.putString("exceptionId", String.valueOf(id));
             event.reply(response);
             return;
         }

--- a/src/main/java/org/usergrid/vx/server/operations/CreateMultiProcessHandler.java
+++ b/src/main/java/org/usergrid/vx/server/operations/CreateMultiProcessHandler.java
@@ -36,7 +36,7 @@ public class CreateMultiProcessHandler implements Handler<Message<JsonObject>>{
       event.reply(new JsonObject()
         .putString(id.toString(), e.getClass().getName())
         .putString("exception", e.getMessage())
-        .putNumber("exceptionId", id));
+        .putString("exceptionId", String.valueOf(id)));
     } 
     
   }

--- a/src/main/java/org/usergrid/vx/server/operations/CreateProcessorHandler.java
+++ b/src/main/java/org/usergrid/vx/server/operations/CreateProcessorHandler.java
@@ -45,7 +45,7 @@ public class CreateProcessorHandler implements Handler<Message<JsonObject>>{
       event.reply(new JsonObject()
         .putString(id.toString(), e.getClass().getName())
         .putString("exception", e.getMessage())
-        .putNumber("exceptionId", id));
+        .putString("exceptionId", String.valueOf(id)));
     } 
     
   }


### PR DESCRIPTION
The OperationsRequestHandler expects the exceptionId to be a string, but there are places where it was stored as a number.  
