### PR TITLE
examples/json/create_schema.sh not working

### DIFF
--- a/examples/json/create_schema.sh
+++ b/examples/json/create_schema.sh
@@ -1,3 +1,3 @@
 echo "Creating keyspace 'myks' and column family 'mycf'"
-curl -vX POST http://localhost:8080/intravert/intrareq-json -d "{\"e\":[ {\"type\":\"CREATEKEYSPACE\",\"op\":{\"name\":\"myks\",\"replication\":1}}, {\"type\":\"CREATECOLUMNFAMILY\",\"op\":{\"name\":\"mycf\"}} ]}"
+curl -vX POST http://localhost:8080/intravert/intrareq-json -d "{\"e\":[ {\"type\":\"CREATEKEYSPACE\",\"op\":{\"name\":\"myks\",\"replication\":1}}, {\"type\":\"SETKEYSPACE\",\"op\":{\"keyspace\":\"myks\"}}, {\"type\":\"CREATECOLUMNFAMILY\",\"op\":{\"name\":\"mycf\"}} ]}"
 echo


### PR DESCRIPTION
Create CF was failing because the KS was not set. 
added SETKEYSPACE to the example

Closes #194
