### PR TITLE
Handle ArrayLists in HandlerUtils.resolveObject()

### DIFF
--- a/src/main/java/org/usergrid/vx/server/operations/HandlerUtils.java
+++ b/src/main/java/org/usergrid/vx/server/operations/HandlerUtils.java
@@ -352,6 +352,8 @@ public class HandlerUtils {
   public static Object resolveObject(Object o) {
     if (o instanceof JsonArray) {
       return ((JsonArray) o).toArray();
+    } else if (o instanceof ArrayList) {
+        return ((ArrayList) o).toArray();
     } else if (o instanceof Object[]) {
       return o;
     } else if (o instanceof Integer) {


### PR DESCRIPTION
Jackson returns an ArrayList for JSON lists, I'm using those for composite keys.
