### PR TITLE
Create testing that uses json rather then java code

### DIFF
--- a/src/main/java/io/teknek/intravert/action/impl/UpsertAction.java
+++ b/src/main/java/io/teknek/intravert/action/impl/UpsertAction.java
@@ -1,17 +1,11 @@
 package io.teknek.intravert.action.impl;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.RowMutation;
 import org.apache.cassandra.db.filter.QueryPath;
-import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
@@ -19,9 +13,6 @@ import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import io.teknek.intravert.action.Action;
-import io.teknek.intravert.action.filter.Filter;
-import io.teknek.intravert.action.filter.FilterFactory;
-import io.teknek.intravert.model.Constants;
 import io.teknek.intravert.model.Operation;
 import io.teknek.intravert.model.Response;
 import io.teknek.intravert.service.ApplicationContext;

--- a/src/test/java/io/teknek/intravert/daemon/JsonFileTest.java
+++ b/src/test/java/io/teknek/intravert/daemon/JsonFileTest.java
@@ -1,0 +1,50 @@
+package io.teknek.intravert.daemon;
+
+import io.teknek.intravert.client.Client;
+import io.teknek.intravert.model.Request;
+import io.teknek.intravert.model.Response;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import junit.framework.Assert;
+
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig.Feature;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JsonFileTest extends BaseIntravertTest {
+
+  private File jtest;
+  
+  @Before
+  public void before(){
+    File resources = new File("src/test/resources");
+    jtest = new File(resources, "jtest");
+  }
+  
+  public void innerTest(String testname) throws JsonParseException, JsonMappingException, IOException{
+    File testDir = new File(jtest, testname);
+    if (!testDir.isDirectory()){
+      throw new RuntimeException(testDir+" is not a directory");
+    }
+    File input = new File(testDir, "input.json");
+    File output = new File(testDir, "output.json");
+    Client c = new Client();
+    ObjectMapper om  = new ObjectMapper();
+    om.configure(Feature.INDENT_OUTPUT, true);
+    Request r = om.readValue(input, Request.class);
+    Response resp = c.post("http://localhost:7654", r);
+    Assert.assertEquals(new String(Files.readAllBytes(output.toPath())).trim(), om.writeValueAsString(resp).trim());
+  }
+  
+  @Test
+  public void test() throws JsonParseException, JsonMappingException, IOException{
+    innerTest("putget");
+  }
+}

--- a/src/test/java/io/teknek/intravert/daemon/UpsertTest.java
+++ b/src/test/java/io/teknek/intravert/daemon/UpsertTest.java
@@ -20,6 +20,8 @@ import org.apache.cassandra.config.KSMetaData;
 import org.apache.cassandra.config.Schema;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig.Feature;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -52,6 +54,9 @@ public class UpsertTest extends BaseIntravertTest {
             .put("keyspace","example")
             .put("columnFamily", "upsert").build()));
     Client cl = new Client();
+    ObjectMapper om = new ObjectMapper();
+    om.configure(Feature.INDENT_OUTPUT,true);
+    System.out.println(om.writeValueAsString(request));
     Response response = cl.post("http://127.0.0.1:7654", request);
     List<Map> results = (List<Map>) response.getResults().get("1");
     Assert.assertEquals(new ImmutableMap.Builder<String, Object>().put("result", "ok").build(), results.get(0));

--- a/src/test/resources/jtest/putget/input.json
+++ b/src/test/resources/jtest/putget/input.json
@@ -1,0 +1,35 @@
+{
+  "operations" : [ {
+    "type" : "createkeyspace",
+    "id" : "0",
+    "arguments" : {
+      "name" : "example",
+      "replication" : 1,
+      "ignoreIfNotExists" : true
+    }
+  }, {
+    "type" : "createcolumnfamily",
+    "id" : "1",
+    "arguments" : {
+      "keyspace" : "example",
+      "columnFamily" : "upsert",
+      "ignoreIfNotExists" : true
+    }
+  }, {
+    "type" : "setkeyspace",
+    "id" : "2",
+    "arguments" : {
+      "name" : "example"
+    }
+  }, {
+    "type" : "upsert",
+    "id" : "3",
+    "arguments" : {
+      "rowkey" : "ecapriolo",
+      "column" : "firstname",
+      "value" : "edward",
+      "keyspace" : "example",
+      "columnFamily" : "upsert"
+    }
+  } ]
+}

--- a/src/test/resources/jtest/putget/output.json
+++ b/src/test/resources/jtest/putget/output.json
@@ -1,0 +1,19 @@
+{
+  "exceptionMessage" : null,
+  "exceptionId" : null,
+  "results" : {
+    "3" : [ {
+      "result" : "ok"
+    } ],
+    "2" : [ {
+      "result" : "ok"
+    } ],
+    "1" : [ {
+      "result" : "ok"
+    } ],
+    "0" : [ {
+      "status" : "ok"
+    } ]
+  },
+  "metaData" : { }
+}


### PR DESCRIPTION
Having tests that start and end with json is more self documenting and cleaner in some cases. This should make it easier to evolve the project. input.json is read into a request. The request is sent. Then the response compared with output.json. A future enhancement would be to do the same testing without the http transport for better step-ability
