### PR TITLE
Use linked hash map so that elements in result hash map are ordered as t...

### DIFF
--- a/src/main/java/io/teknek/intravert/model/Response.java
+++ b/src/main/java/io/teknek/intravert/model/Response.java
@@ -1,17 +1,18 @@
 package io.teknek.intravert.model;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Response {
   private String exceptionMessage;
   private String exceptionId;
-  private Map<String,Object> results;
-  private Map<String,Object> metaData;
+  private LinkedHashMap<String,Object> results;
+  private LinkedHashMap<String,Object> metaData;
   
   public Response(){
-    results = new HashMap<String,Object>();
-    metaData = new HashMap<String,Object>();
+    results = new LinkedHashMap<String,Object>();
+    metaData = new LinkedHashMap<String,Object>();
   }
 
   public String getExceptionMessage() {
@@ -34,7 +35,7 @@ public class Response {
     return results;
   }
 
-  public void setResults(Map<String, Object> results) {
+  public void setResults(LinkedHashMap<String, Object> results) {
     this.results = results;
   }
 
@@ -42,7 +43,7 @@ public class Response {
     return metaData;
   }
 
-  public void setMetaData(Map<String, Object> metaData) {
+  public void setMetaData(LinkedHashMap<String, Object> metaData) {
     this.metaData = metaData;
   }
   

--- a/src/test/java/io/teknek/intravert/daemon/JsonFileTest.java
+++ b/src/test/java/io/teknek/intravert/daemon/JsonFileTest.java
@@ -44,7 +44,7 @@ public class JsonFileTest extends BaseIntravertTest {
   }
   
   @Test
-  public void test() throws JsonParseException, JsonMappingException, IOException{
+  public void putGetTest() throws JsonParseException, JsonMappingException, IOException{
     innerTest("putget");
   }
 }

--- a/src/test/resources/jtest/putget/output.json
+++ b/src/test/resources/jtest/putget/output.json
@@ -2,17 +2,17 @@
   "exceptionMessage" : null,
   "exceptionId" : null,
   "results" : {
-    "3" : [ {
+    "0" : [ {
+      "status" : "ok"
+    } ],
+    "1" : [ {
       "result" : "ok"
     } ],
     "2" : [ {
       "result" : "ok"
     } ],
-    "1" : [ {
+    "3" : [ {
       "result" : "ok"
-    } ],
-    "0" : [ {
-      "status" : "ok"
     } ]
   },
   "metaData" : { }


### PR DESCRIPTION
We want the results to be ordered as the results are executed to avoid confusion.
