### PR TITLE
Cleanup pom so surefire does not stop test from running, in column famil...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
-                        <artifactId>junit</artifactId>
-                        <version>4.10</version>
-                        <scope>test</scope>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
@@ -63,29 +63,28 @@
 			<artifactId>json-path</artifactId>
 			<version>0.8.1</version>
 		</dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
-        </dependency>
-                        <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty</artifactId>
-        <version>7.0.0.pre5</version>
-</dependency>
-<dependency>
-<groupId>org.apache.httpcomponents</groupId>
-<artifactId>httpclient</artifactId>
-<version>4.1.1</version>
-</dependency>
-        
-    </dependencies>
-    
-	<build>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>jetty</artifactId>
+			<version>7.0.0.pre5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.1.1</version>
+		</dependency>
+
+	</dependencies>
+	<build> 
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-                		<version>3.0</version>
+				<version>3.0</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
@@ -94,59 +93,6 @@
 					<showWarnings>true</showWarnings>
 				</configuration>
 			</plugin>
-            <!-- demarcation of integration tests with unit tests -->
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.13</version>
-                <configuration>
-                    <systemProperties combine.children="append">
-                        <dataDir>${basedir}/src/test/resources</dataDir>
-                      <async-requests-enabled>${async-requests-enabled}}</async-requests-enabled>
-                    </systemProperties>
-                    <!--
-                    <properties>
-                        <property>
-                            <name>listener</name>
-                            <value>org.hectorclient.testutils.CassandraRunListener</value>
-                        </property>
-                    </properties>
-                    -->
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <skip>false</skip>
-                            <includes>
-                                <include>**/*ITest.java</include>
-                            </includes>
-                            <excludes>
-                                <exclude>**/*UnitTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- run unit tests in parallel -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.13</version>
-                <configuration>
-                    <parallel>methods</parallel>
-                    <threadCount>10</threadCount>
-                    <includes>
-                        <include>**/*UnitTest.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/*ITest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/io/teknek/intravert/action/impl/CreateColumnFamilyAction.java
+++ b/src/main/java/io/teknek/intravert/action/impl/CreateColumnFamilyAction.java
@@ -1,12 +1,5 @@
 package io.teknek.intravert.action.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.cassandra.config.CFMetaData;
 import org.apache.cassandra.config.KSMetaData;
 import org.apache.cassandra.config.Schema;
@@ -14,10 +7,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.service.MigrationManager;
 import org.apache.cassandra.thrift.CfDef;
-import org.apache.cassandra.thrift.KsDef;
-
 import io.teknek.intravert.action.Action;
-import io.teknek.intravert.model.Constants;
 import io.teknek.intravert.model.Operation;
 import io.teknek.intravert.model.Response;
 import io.teknek.intravert.service.ApplicationContext;
@@ -35,7 +25,8 @@ public class CreateColumnFamilyAction implements Action {
     if (!Schema.instance.getNonSystemTables().contains(keyspace)){
       throw new RuntimeException("keyspace "+ keyspace + " does not exist");
     }
-    if (false){
+    KSMetaData ks = Schema.instance.getKSMetaData(keyspace);
+    if (ks.cfMetaData().containsKey(columnFamily)){
       if (ignoreIfNotExists){
         response.getResults().put(operation.getId(), ResponseUtil.getDefaultHappy());
         return;


### PR DESCRIPTION
A while back we decided to separate itests from unit tests and have a complex sure fire configuration. Over time I have forgotten what arguments run each tests suite and running tests inside eclipse is not running the same tests as mvn test. This was hiding bugs. I have removed all the custom surefire stuff that made the project more complex mvn test now runs all tests.
